### PR TITLE
fix(hooks): initialize useRef with nullable type to unblock Vercel build

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -28,7 +28,8 @@ export const useSettings = (subscribeToKeys?: (keyof AppSettings)[]) => {
   });
 
   const [isInitialized, setIsInitialized] = useState(false);
-  const previousSettingsRef = useRef<AppSettings>();
+  // FIX: initialize ref with null and allow nullable type for strict TS
+  const previousSettingsRef = useRef<AppSettings | null>(null);
   const settingsHashRef = useRef<string>("");
 
   // Memoize settings to prevent unnecessary re-renders
@@ -36,7 +37,7 @@ export const useSettings = (subscribeToKeys?: (keyof AppSettings)[]) => {
     // Create a hash of the settings to check for actual changes
     const currentHash = JSON.stringify(settings);
     
-    // Only return new object if settings actually changed
+    // Only return previous object if settings actually didn't change
     if (previousSettingsRef.current && settingsHashRef.current === currentHash) {
       return previousSettingsRef.current;
     }
@@ -53,7 +54,7 @@ export const useSettings = (subscribeToKeys?: (keyof AppSettings)[]) => {
     setSettings(storedSettings);
     setIsInitialized(true);
 
-    // Subscribe with selective updates - FIX: Add proper callback function
+    // Subscribe with selective updates
     const unsubscribe = settingsStorage.subscribe(
       (newSettings, oldSettings, changedKeys) => {
         // Only update if settings actually changed and we care about the keys
@@ -140,7 +141,7 @@ export const useSettings = (subscribeToKeys?: (keyof AppSettings)[]) => {
     return settingsStorage.getPinnedModels();
   }, []);
 
-  // FIXED: Subscribe function with proper callback signature matching storage.subscribe()
+  // Subscribe function with proper callback signature matching storage.subscribe()
   const subscribe = useCallback((callback: (settings: AppSettings) => void) => {
     return settingsStorage.subscribe((newSettings) => {
       callback(newSettings);


### PR DESCRIPTION
## Summary
Fix Vercel build failure caused by strict TypeScript useRef initialization in `src/hooks/useSettings.ts`.

## Root Cause
`useRef<AppSettings>()` was invoked with no initial value while the generic type is non-nullable. Under strict TS and React 19 types, this is a type error: `Expected 1 arguments, but got 0.`

## Fix
Initialize the ref with a nullable type and a `null` initial value and keep existing null guards:

```ts
- const previousSettingsRef = useRef<AppSettings>();
+ const previousSettingsRef = useRef<AppSettings | null>(null);
```

This aligns with React’s recommended `useRef` usage for mutable containers with late assignment and avoids sharing a mutable default object.

## Safety
- Purely type-level/runtime-safe fix; no behavior change.
- Existing code already checks `previousSettingsRef.current` before using it.
- Unblocks `npm run build` on Vercel.

## Policy Alignment
- Small, atomic hotfix.
- Strict TypeScript adherence, no weakening of types.
- No secrets, no API changes.

## Verification
- `npm run typecheck` passes locally/CI.
- Vercel should proceed past type checking.

Closes: Vercel build failure reported in logs.