### PR TITLE
chore(ci): retrigger Vercel preview after repo transfer

### DIFF
--- a/docs/.vercel-preview-retrigger.txt
+++ b/docs/.vercel-preview-retrigger.txt
@@ -1,0 +1,1 @@
+Retigger Preview: 2025-10-13 23:53:00


### PR DESCRIPTION
Trigger Vercel preview deployment after repository transfer. This PR is a no-op change to re-establish preview builds and verify Git integration following reconnection.

- Adds docs/.vercel-preview-retrigger.txt marker file
- Confirms Vercel GitHub App hooks are firing on this repository
- Safe to merge or close after confirming preview builds
