### PR TITLE
fix(react): do not emit undefined onError under exactOptionalPropertyTypes to unblock Vercel build

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -187,10 +187,16 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export const AppErrorBoundary: React.FC<{ children: ReactNode; onError?: Props['onError'] }> = ({ children, onError }) => (
-  <ErrorBoundary level="app" onError={onError}>
-    {children}
-  </ErrorBoundary>
-);
+export const AppErrorBoundary: React.FC<{ children: ReactNode; onError?: Props['onError'] }> = ({ children, onError }) => {
+  const boundaryProps: Omit<Props, 'children'> = { level: 'app' };
+  if (onError) {
+    boundaryProps.onError = onError;
+  }
+  return (
+    <ErrorBoundary {...boundaryProps}>
+      {children}
+    </ErrorBoundary>
+  );
+};
 
 export default ErrorBoundary;


### PR DESCRIPTION
Summary
This PR unblocks Vercel builds under TypeScript `"exactOptionalPropertyTypes": true` by ensuring optional props are not emitted as `undefined` at JSX callsites and by complementing prior typing fixes in `ErrorContext`.

What changed
- components: ErrorBoundary.tsx
  - Update `AppErrorBoundary` to construct a `Props` object for `<ErrorBoundary>` and only include `onError` when it is actually defined. This avoids passing `onError={onError}` when `onError` is `undefined`, which was flagged by TS under `exactOptionalPropertyTypes`.

Rationale
- Vercel logs showed:
  - `Type error: Type '{ children: ReactNode; level: "app"; onError: ((error: AppError, errorInfo: ErrorInfo) => void) | undefined; }' is not assignable to type 'Readonly<Props>' with 'exactOptionalPropertyTypes: true'.`
- With `exactOptionalPropertyTypes`, optional props must not be emitted with `undefined` at callsites. This PR makes that explicit and aligns usage with strict TS expectations without loosening compiler settings.

How this PR interacts with the previous fix
- The earlier PR (exactOptionalPropertyTypes + Next ESLint) updated:
  - `src/types/errors.ts` to explicitly allow `undefined` for optional fields and preserve `undefined` in context merging
  - Added `.eslintrc.json` to extend `["next", "next/core-web-vitals"]`
- This PR addresses the remaining JSX callsite emission issue.

Testing & Validation
- Typecheck (local): `npm run typecheck` passes on changed files
- Lint: Project uses ESLint; with `.eslintrc.json` from the previous PR, the Next plugin warning will be removed after both PRs are merged
- Functional: `ErrorBoundary` behavior unchanged; only prop emission policy changed (no `undefined` prop passed)

Risk
- Low. Change is isolated to wrapper component and does not alter runtime behavior except avoiding an `undefined` prop.

Acceptance criteria
- Vercel build no longer fails with the `onError` assignability error
- No regression in error reporting via `onError` when provided

Follow-ups (separate PRs by policy)
- Husky modernization to remove `install` deprecation notice (non-blocking)
- Add a `tsd` assertion for the JSX callsite pattern to prevent regression
