### PR TITLE
Fix eslint nextjs plugin detection

### DIFF
--- a/src/components/ImageToPromptTab.tsx
+++ b/src/components/ImageToPromptTab.tsx
@@ -13,6 +13,7 @@ import {
   DollarSign,
   Copy,
   Check,
+  Calculator,
 } from "lucide-react";
 import Image from "next/image";
 


### PR DESCRIPTION
## Title

Fix: Resolve Next.js ESLint plugin detection warning

## What changed

- Updated `eslint.config.mjs` to correctly integrate the Next.js ESLint plugin using `FlatCompat` for ESLint v9 flat config.
- Reorganized ESLint configuration to prevent parser conflicts and moved type-aware rules to TypeScript-specific sections.
- Removed the `globals` package dependency from ESLint config.
- Added missing `Calculator` import to `src/components/ImageToPromptTab.tsx`.

## Why

- The Vercel build was failing with a warning: "The Next.js plugin was not detected in your ESLint configuration." This change ensures Next.js-specific ESLint rules are properly applied during the build process.
- The missing `Calculator` import was causing a build error.

## How to verify

1. Run `npm install` to ensure all dependencies are correctly installed.
2. Run `npm run build`.
3. Verify that the warning "The Next.js plugin was not detected in your ESLint configuration" no longer appears in the build output.
4. Confirm the build completes successfully without errors.

## Risks / Limitations

- ESLint configuration changes can sometimes introduce new linting warnings or errors if not thoroughly tested across the codebase. This fix specifically targets the Next.js plugin detection; other existing linting warnings (e.g., React Compiler issues) may still be present.

## Size

~10/13 lines

## Definition of Done (DoD)

- [ ] No secrets / .env added or modified
- [ ] No changes under `.github/**` unless intentional and approved
- [ ] Lint clean (zero warnings): The specific Next.js plugin detection warning is resolved. Other existing lint warnings may persist.
- [ ] Typecheck clean: `npm run typecheck`
- [ ] Tests passing: `npm test -- --runInBand`
- [ ] Branch is up to date with `main`
- [ ] Clear PR body (What/Why/How to verify + Risks + Size)
- [ ] Screenshot/GIF if UI changed: N/A
- [ ] Acceptance criteria met; linked issue/epic; ADR linked or "N/A": N/A
- [ ] Backward compatibility preserved, or breaking change documented with migration path
- [ ] Feature guarded by a flag or has a safe rollout plan and kill switch: N/A
- [ ] Observability updated: logs/metrics/traces; alerts/dashboards updated or "N/A": N/A
- [ ] Performance budgets respected; no regressions verified locally (note perf risks if any): N/A
- [ ] Security/privacy reviewed: no PII in logs; deps changes pass audit
- [ ] Accessibility verified (labels, keyboard nav, color contrast): N/A
- [ ] API/schema changes documented; all consumers updated or "N/A": N/A
- [ ] Data/storage migrations include scripts, tests, and rollback plan or "N/A": N/A
- [ ] Documentation updated (user/dev); README/CHANGELOG updated if user-visible: N/A
- [ ] Rollout and rollback plan captured in "How to verify" or "Risks"
- [ ] Tests added/updated (unit/integration/e2e) for new behavior: N/A (config fix)
- [ ] i18n: user-facing strings externalized and ready for translation or "N/A": N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-06d49bc5-24bc-4c47-8857-8b4bc3f74d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06d49bc5-24bc-4c47-8857-8b4bc3f74d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

