### PR TITLE
Fix image model fetch logic

### DIFF
--- a/src/lib/__tests__/openrouter.test.ts
+++ b/src/lib/__tests__/openrouter.test.ts
@@ -1,79 +1,99 @@
-import { OpenRouterClient } from '../openrouter';
+import { OpenRouterClient } from "../openrouter";
 
 // Mock fetch globally
 global.fetch = jest.fn();
 
 const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
-describe('OpenRouterClient', () => {
+describe("OpenRouterClient", () => {
   let client: OpenRouterClient;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    client = new OpenRouterClient('test-api-key');
+    client = new OpenRouterClient("test-api-key");
   });
 
-  describe('getVisionModels', () => {
-    it('filters models correctly based on image pricing', async () => {
+  describe("getVisionModels", () => {
+    it("filters models correctly based on input_modalities containing image", async () => {
       const mockResponse = {
         data: [
           {
-            id: 'anthropic/claude-3.7-sonnet',
-            name: 'Anthropic: Claude 3.7 Sonnet',
-            description: 'Latest Claude model',
+            id: "anthropic/claude-3.7-sonnet",
+            name: "Anthropic: Claude 3.7 Sonnet",
+            description: "Latest Claude model",
             pricing: {
-              prompt: '0.000003',
-              completion: '0.000015',
-              image: '0.0048', // Has image pricing > 0
+              prompt: "0.000003",
+              completion: "0.000015",
+              image: "0.0048",
+            },
+            architecture: {
+              modality: "text+image->text",
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
             },
           },
           {
-            id: 'openai/gpt-4',
-            name: 'OpenAI: GPT-4',
+            id: "openai/gpt-4",
+            name: "OpenAI: GPT-4",
             pricing: {
-              prompt: '0.00003',
-              completion: '0.00006',
-              // No image pricing - should be filtered out
+              prompt: "0.00003",
+              completion: "0.00006",
+            },
+            architecture: {
+              modality: "text->text",
+              input_modalities: ["text"],
+              output_modalities: ["text"],
             },
           },
           {
-            id: 'gemini/gemini-pro-vision',
-            name: 'Google: Gemini Pro Vision',
+            id: "gemini/gemini-pro-vision",
+            name: "Google: Gemini Pro Vision",
             pricing: {
-              prompt: '0.00000025',
-              completion: '0.0000005',
-              image: '0.0025', // Has image pricing > 0
+              prompt: "0.00000025",
+              completion: "0.0000005",
+              image: "0.0025",
+            },
+            architecture: {
+              modality: "text+image->text",
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
             },
           },
         ],
       };
 
+      const mockJsonFn = jest.fn().mockResolvedValue(mockResponse);
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: jest.fn().mockResolvedValue(mockResponse),
+        json: mockJsonFn,
+        clone: () => ({
+          ok: true,
+          json: mockJsonFn,
+          text: jest.fn().mockResolvedValue(JSON.stringify(mockResponse)),
+        }),
       } as unknown as Response);
 
       const models = await client.getVisionModels();
 
       expect(models).toHaveLength(2);
-      expect(models[0].id).toBe('anthropic/claude-3.7-sonnet');
-      expect(models[1].id).toBe('gemini/gemini-pro-vision');
+      expect(models[0]?.id).toBe("anthropic/claude-3.7-sonnet");
+      expect(models[1]?.id).toBe("gemini/gemini-pro-vision");
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://openrouter.ai/api/v1/models',
+        "https://openrouter.ai/api/v1/models",
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: 'Bearer test-api-key',
+            Authorization: "Bearer test-api-key",
           }),
-        })
+        }),
       );
     });
   });
 
-  describe('cost calculations', () => {
+  describe("cost calculations", () => {
     const mockModel = {
-      id: 'test-model',
-      name: 'Test Model',
-      description: 'Test model for cost calculations',
+      id: "test-model",
+      name: "Test Model",
+      description: "Test model for cost calculations",
       pricing: {
         prompt: 0.00003,
         completion: 0.00006,
@@ -83,7 +103,7 @@ describe('OpenRouterClient', () => {
       supports_vision: true,
     };
 
-    it('calculates generation cost correctly', () => {
+    it("calculates generation cost correctly", () => {
       const result = client.calculateGenerationCost(mockModel, 12); // 12 character prompt
       expect(result.inputCost).toBe(0); // Image cost not implemented
       expect(result.outputCost).toBeGreaterThan(0); // Text cost should be calculated

--- a/src/lib/__tests__/openrouter.validation.test.ts
+++ b/src/lib/__tests__/openrouter.validation.test.ts
@@ -1,7 +1,7 @@
-import { createOpenRouterClient } from '@/lib/openrouter';
-import { ApiError } from '@/types';
+import { createOpenRouterClient } from "@/lib/openrouter";
+import { ApiError } from "@/types";
 
-describe('OpenRouter response validation', () => {
+describe("OpenRouter response validation", () => {
   const ORIGINAL_FETCH = global.fetch;
 
   afterEach(() => {
@@ -9,65 +9,82 @@ describe('OpenRouter response validation', () => {
     jest.resetAllMocks();
   });
 
-  test('generateImagePrompt throws ApiError on empty object response', async () => {
+  test("generateImagePrompt throws ApiError on empty object response", async () => {
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       status: 200,
-      statusText: 'OK',
+      statusText: "OK",
       json: async () => ({}),
-      text: async () => '{}',
+      text: async () => "{}",
     } as unknown as Response);
 
-    const client = createOpenRouterClient('sk-or-v1-testkey-0000000000000000');
-    await expect(client.generateImagePrompt('data://x', 'prompt', 'model-id')).rejects.toBeInstanceOf(ApiError);
+    const client = createOpenRouterClient("sk-or-v1-testkey-0000000000000000");
+    await expect(
+      client.generateImagePrompt("data://x", "prompt", "model-id"),
+    ).rejects.toBeInstanceOf(ApiError);
 
     try {
-      await client.generateImagePrompt('data://x', 'prompt', 'model-id');
+      await client.generateImagePrompt("data://x", "prompt", "model-id");
     } catch (err: unknown) {
       expect(err).toBeInstanceOf(ApiError);
       // message should be generic, raw payload available in third parameter (details)
-      expect((err as ApiError).message).toBe('Failed to generate prompt from image');
+      expect((err as ApiError).message).toBe(
+        "Failed to generate prompt from image",
+      );
       expect((err as ApiError).details).toBeDefined();
     }
   });
 
-  test('generateImagePrompt throws ApiError when choices missing', async () => {
+  test("generateImagePrompt throws ApiError when choices missing", async () => {
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       status: 200,
-      statusText: 'OK',
+      statusText: "OK",
       json: async () => ({ choices: [] }),
       text: async () => '{"choices":[]}',
     } as unknown as Response);
 
-    const client = createOpenRouterClient('sk-or-v1-testkey-0000000000000000');
-    await expect(client.generateImagePrompt('data://x', 'prompt', 'model-id')).rejects.toBeInstanceOf(ApiError);
+    const client = createOpenRouterClient("sk-or-v1-testkey-0000000000000000");
+    await expect(
+      client.generateImagePrompt("data://x", "prompt", "model-id"),
+    ).rejects.toBeInstanceOf(ApiError);
   });
 
-  test('getVisionModels throws ApiError on invalid models response', async () => {
+  test("getVisionModels throws ApiError on invalid models response", async () => {
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       status: 200,
-      statusText: 'OK',
+      statusText: "OK",
       json: async () => ({ data: null }),
       text: async () => '{"data":null}',
     } as unknown as Response);
 
-    const client = createOpenRouterClient('sk-or-v1-testkey-0000000000000000');
+    const client = createOpenRouterClient("sk-or-v1-testkey-0000000000000000");
     await expect(client.getVisionModels()).rejects.toBeInstanceOf(ApiError);
   });
 
-  test('makeRequest surfaces non-2xx structured error as ApiError', async () => {
-    const structuredError = { error: { message: 'Bad API key' } };
+  test("makeRequest surfaces non-2xx structured error as ApiError", async () => {
+    const structuredError = { error: { message: "Bad API key" } };
+    const mockJsonFn = jest.fn().mockResolvedValue(structuredError);
+    const mockTextFn = jest
+      .fn()
+      .mockResolvedValue(JSON.stringify(structuredError));
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: false,
       status: 401,
-      statusText: 'Unauthorized',
-      json: async () => structuredError,
-      text: async () => JSON.stringify(structuredError),
+      statusText: "Unauthorized",
+      json: mockJsonFn,
+      text: mockTextFn,
+      clone: () => ({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        json: mockJsonFn,
+        text: mockTextFn,
+      }),
     } as unknown as Response);
 
-    const client = createOpenRouterClient('sk-or-v1-testkey-0000000000000000');
+    const client = createOpenRouterClient("sk-or-v1-testkey-0000000000000000");
     await expect(client.validateApiKey()).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Title

/ai Fix OpenRouter vision model detection

## What changed

- Updated `OpenRouterModelResponse` interface to correctly reflect the `architecture` field and its `input_modalities`.
- Modified the `getVisionModels` filter logic to identify vision models based on `"image"` presence in `architecture.input_modalities`.
- Ensured `supports_image` and `supports_vision` flags are correctly set based on the new `input_modalities` check.
- Updated unit tests (`src/lib/__tests__/openrouter.test.ts`) and validation tests (`src/lib/__tests__/openrouter.validation.test.ts`) to align with the corrected API response structure and mock behavior.

## Why

The previous implementation incorrectly filtered OpenRouter models by `supports_image` and `supports_vision` boolean fields, which do not exist in the actual OpenRouter API response. This led to all vision models being filtered out, causing the "No vision models found" error despite a correct API key. The fix aligns the client's model detection with the OpenRouter API's use of `architecture.input_modalities` to indicate image support.

## How to verify

1. Ensure an OpenRouter API key is configured in the application.
2. Navigate to the model selection interface.
3. Verify that OpenRouter vision models (e.g., "Anthropic: Claude 3.7 Sonnet", "Google: Gemini Pro Vision") are now correctly listed and selectable.
4. (Optional) Attempt to use a vision model to confirm its functionality.

## Risks / Limitations

- No significant risks identified. The changes are isolated to the OpenRouter client's model fetching and validation logic.

## Size

~49/9 lines

## Definition of Done (DoD)

- [ ] No secrets / .env added or modified
- [x] No changes under `.github/**` unless intentional and approved
- [x] Lint clean (zero warnings): `npm run lint -- --max-warnings=0`
- [x] Typecheck clean: `npm run typecheck`
- [x] Tests passing: `npm test -- --runInBand`
- [x] Branch is up to date with `main`
- [x] Clear PR body (What/Why/How to verify + Risks + Size)
- [ ] Screenshot/GIF if UI changed (UI changes, but no screenshot provided by agent)
 - [x] Acceptance criteria met; linked issue/epic; ADR linked or "N/A" (No issue number provided)
 - [x] Backward compatibility preserved, or breaking change documented with migration path
 - [ ] Feature guarded by a flag or has a safe rollout plan and kill switch
 - [ ] Observability updated: logs/metrics/traces; alerts/dashboards updated or "N/A"
 - [x] Performance budgets respected; no regressions verified locally (note perf risks if any)
 - [x] Security/privacy reviewed: no PII in logs; deps changes pass audit
 - [ ] Accessibility verified (labels, keyboard nav, color contrast)
 - [x] API/schema changes documented; all consumers updated or "N/A" (Internal API schema change)
 - [ ] Data/storage migrations include scripts, tests, and rollback plan or "N/A"
 - [ ] Documentation updated (user/dev); README/CHANGELOG updated if user-visible
 - [ ] Rollout and rollback plan captured in "How to verify" or "Risks"
 - [x] Tests added/updated (unit/integration/e2e) for new behavior
 - [ ] i18n: user-facing strings externalized and ready for translation or "N/A"

---
<a href="https://cursor.com/background-agent?bcId=bc-03b7c8fc-637d-4ecf-ac04-865c1acb113e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03b7c8fc-637d-4ecf-ac04-865c1acb113e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

