### PR TITLE
fix: ImageToPromptTab JSX syntax error causing Vercel build failures

### DIFF
--- a/src/components/ImageToPromptTab.tsx
+++ b/src/components/ImageToPromptTab.tsx
@@ -12,6 +12,8 @@ import {
   Loader2,
   Calculator,
   DollarSign,
+  Check,
+  Copy,
 } from "lucide-react";
 import Image from "next/image";
 
@@ -294,8 +296,10 @@ export const ImageToPromptTab: React.FC<ImageToPromptTabProps> = ({
 
           // Calculate input/output costs based on model pricing
           if (model.pricing) {
-            const inputPrice = parseFloat(model.pricing.prompt || "0");
-            const outputPrice = parseFloat(model.pricing.completion || "0");
+            const inputPrice = parseFloat(String(model.pricing.prompt || "0"));
+            const outputPrice = parseFloat(
+              String(model.pricing.completion || "0"),
+            );
             inputCost = (inputTokens * inputPrice) / 1000000; // Convert from per-1M tokens
             outputCost = (outputTokens * outputPrice) / 1000000;
           }
@@ -355,6 +359,11 @@ export const ImageToPromptTab: React.FC<ImageToPromptTabProps> = ({
   const formatCost = useCallback((cost: number | null): string => {
     if (cost === null || cost === 0) return "$0.000000";
     return `$${cost.toFixed(6)}`;
+  }, []);
+
+  const formatTokens = useCallback((tokens: number | null): string => {
+    if (tokens === null) return "0";
+    return tokens.toLocaleString();
   }, []);
 
   const copyToClipboard = useCallback(async (text: string, modelId: string) => {
@@ -694,7 +703,7 @@ export const ImageToPromptTab: React.FC<ImageToPromptTabProps> = ({
                       </p>
                     </div>
                   )}
-                </>
+                </div>
               )}
             </div>
           ))}


### PR DESCRIPTION
Mode: 0 (Normal)
RCA: Three critical issues in ImageToPromptTab.tsx prevented successful builds:
1. Orphaned JSX fragment closer `</>` on line 697 with no matching opening tag
2. Missing imports for Check and Copy icons from lucide-react (used in copy button)
3. Missing formatTokens helper function (referenced but not defined)
4. TypeScript type error in parseFloat calls with union types

Minimal fix:
- Removed orphaned `</>` fragment and replaced with proper `</div>` closing tag
- Added Check and Copy to lucide-react imports
- Implemented formatTokens callback to format token counts with locale strings
- Added String() wrapper for parseFloat type safety

Tests: Build verified with `npm run build` - exits successfully

## Title

<short imperative> (Fixes #<NUMBER>)

## What changed

-

## Why

-

## How to verify

1.
2.
3.

## Risks / Limitations

-

## Size

~<added>/<removed> lines

## Definition of Done (DoD)

- [ ] No secrets / .env added or modified
- [ ] No changes under `.github/**` unless intentional and approved
- [ ] Lint clean (zero warnings): `npm run lint -- --max-warnings=0`
- [ ] Typecheck clean: `npm run typecheck`
- [ ] Tests passing: `npm test -- --runInBand`
- [ ] Branch is up to date with `main`
- [ ] Clear PR body (What/Why/How to verify + Risks + Size)
- [ ] Screenshot/GIF if UI changed
 - [ ] Acceptance criteria met; linked issue/epic; ADR linked or "N/A"
 - [ ] Backward compatibility preserved, or breaking change documented with migration path
 - [ ] Feature guarded by a flag or has a safe rollout plan and kill switch
 - [ ] Observability updated: logs/metrics/traces; alerts/dashboards updated or "N/A"
 - [ ] Performance budgets respected; no regressions verified locally (note perf risks if any)
 - [ ] Security/privacy reviewed: no PII in logs; deps changes pass audit
 - [ ] Accessibility verified (labels, keyboard nav, color contrast)
 - [ ] API/schema changes documented; all consumers updated or "N/A"
 - [ ] Data/storage migrations include scripts, tests, and rollback plan or "N/A"
 - [ ] Documentation updated (user/dev); README/CHANGELOG updated if user-visible
 - [ ] Rollout and rollback plan captured in "How to verify" or "Risks"
 - [ ] Tests added/updated (unit/integration/e2e) for new behavior
 - [ ] i18n: user-facing strings externalized and ready for translation or "N/A"
