### PR TITLE
Fix broken tabs and ensure functionality

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from "react";
 import { MainLayout } from "./layout/MainLayout";
 import { SettingsTab } from "./SettingsTab";
+import { BestPracticesTab } from "./BestPracticesTab";
+import { UsageTab } from "./UsageTab";
 import ImageToPromptTabs from "./ImageToPromptTabs";
 import type { TabState } from "@/types";
 import { useSettings } from "@/hooks/useSettings";
@@ -32,6 +34,8 @@ export const App: React.FC = () => {
   return (
     <MainLayout activeTab={tabState.activeTab} onTabChange={handleTabChange}>
       {tabState.activeTab === "image-to-prompt" && <ImageToPromptTabs />}
+      {tabState.activeTab === "best-practices" && <BestPracticesTab />}
+      {tabState.activeTab === "usage" && <UsageTab />}
       {tabState.activeTab === "settings" && (
         <SettingsTab
           settings={settings}

--- a/src/components/__tests__/App.tabs.test.tsx
+++ b/src/components/__tests__/App.tabs.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Tab Integration Test
+ *
+ * This test ensures that all tabs defined in TabNavigation are properly
+ * wired up and rendered in the App component. This prevents the bug where
+ * tabs exist in navigation but don't render any content.
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { App } from "../App";
+
+// Mock the hooks and sub-components
+jest.mock("@/hooks/useSettings", () => ({
+  useSettings: jest.fn(() => ({
+    settings: {
+      apiKey: "test-key",
+      selectedModel: "test-model",
+    },
+    isInitialized: true,
+  })),
+}));
+
+jest.mock("../ImageToPromptTabs", () => ({
+  __esModule: true,
+  default: () => (
+    <div data-testid="image-to-prompt-content">Image to Prompt Tab Content</div>
+  ),
+}));
+
+jest.mock("../BestPracticesTab", () => ({
+  BestPracticesTab: () => (
+    <div data-testid="best-practices-content">Best Practices Tab Content</div>
+  ),
+}));
+
+jest.mock("../UsageTab", () => ({
+  UsageTab: () => <div data-testid="usage-content">Usage Tab Content</div>,
+}));
+
+jest.mock("../SettingsTab", () => ({
+  SettingsTab: () => (
+    <div data-testid="settings-content">Settings Tab Content</div>
+  ),
+}));
+
+describe("App - Tab Integration", () => {
+  it("should render all tabs in navigation", () => {
+    render(<App />);
+
+    // All tabs should be present in navigation - using aria-controls to identify them
+    expect(
+      screen.getByRole("tab", { name: /Image to Prompt/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /Best Practices/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /Usage.*Costs/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Settings/i })).toBeInTheDocument();
+  });
+
+  it("should render Image to Prompt tab content by default", () => {
+    render(<App />);
+    expect(screen.getByTestId("image-to-prompt-content")).toBeInTheDocument();
+  });
+
+  it("should render Best Practices tab content when clicked", () => {
+    render(<App />);
+
+    const bestPracticesTab = screen.getByRole("tab", {
+      name: /Best Practices/i,
+    });
+    fireEvent.click(bestPracticesTab);
+
+    expect(screen.getByTestId("best-practices-content")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("image-to-prompt-content"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render Usage & Costs tab content when clicked", () => {
+    render(<App />);
+
+    const usageTab = screen.getByRole("tab", { name: /Usage.*Costs/i });
+    fireEvent.click(usageTab);
+
+    expect(screen.getByTestId("usage-content")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("image-to-prompt-content"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render Settings tab content when clicked", () => {
+    render(<App />);
+
+    const settingsTab = screen.getByRole("tab", { name: /Settings/i });
+    fireEvent.click(settingsTab);
+
+    expect(screen.getByTestId("settings-content")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("image-to-prompt-content"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should switch between all tabs correctly", () => {
+    render(<App />);
+
+    // Start with Image to Prompt
+    expect(screen.getByTestId("image-to-prompt-content")).toBeInTheDocument();
+
+    // Switch to Best Practices
+    fireEvent.click(screen.getByRole("tab", { name: /Best Practices/i }));
+    expect(screen.getByTestId("best-practices-content")).toBeInTheDocument();
+
+    // Switch to Usage
+    fireEvent.click(screen.getByRole("tab", { name: /Usage.*Costs/i }));
+    expect(screen.getByTestId("usage-content")).toBeInTheDocument();
+
+    // Switch to Settings
+    fireEvent.click(screen.getByRole("tab", { name: /Settings/i }));
+    expect(screen.getByTestId("settings-content")).toBeInTheDocument();
+
+    // Switch back to Image to Prompt
+    fireEvent.click(screen.getByRole("tab", { name: /Image to Prompt/i }));
+    expect(screen.getByTestId("image-to-prompt-content")).toBeInTheDocument();
+  });
+
+  /**
+   * CRITICAL REGRESSION TEST
+   *
+   * This test explicitly verifies that the bug where tabs were defined in
+   * navigation but not rendered in App.tsx doesn't happen again.
+   *
+   * If this test fails, it means a tab exists in TabNavigation but is not
+   * properly wired up to render content in App.tsx.
+   */
+  it("should ensure all navigation tabs have corresponding content rendered", () => {
+    const { container } = render(<App />);
+
+    // Get all tab buttons from navigation
+    const tabButtons = container.querySelectorAll('[role="tab"]');
+    const tabIds = Array.from(tabButtons).map((button) =>
+      button.getAttribute("aria-controls")?.replace("-panel", ""),
+    );
+
+    // Define expected tabs that must have content
+    const expectedTabs = [
+      "image-to-prompt",
+      "best-practices",
+      "usage",
+      "settings",
+    ];
+
+    // Verify all expected tabs are in navigation
+    expectedTabs.forEach((tabId) => {
+      expect(tabIds).toContain(tabId);
+    });
+
+    // Click each tab and verify content is rendered
+    expectedTabs.forEach((tabId) => {
+      const tabButton = container.querySelector(
+        `[aria-controls="${tabId}-panel"]`,
+      );
+      expect(tabButton).toBeInTheDocument();
+
+      if (tabButton) {
+        fireEvent.click(tabButton);
+
+        // Verify some content is rendered (not empty)
+        const contentTestIds = [
+          "image-to-prompt-content",
+          "best-practices-content",
+          "usage-content",
+          "settings-content",
+        ];
+
+        const hasContent = contentTestIds.some((testId) => {
+          try {
+            return screen.getByTestId(testId) !== null;
+          } catch {
+            return false;
+          }
+        });
+
+        expect(hasContent).toBe(true);
+      }
+    });
+  });
+});

--- a/src/components/layout/TabNavigation.tsx
+++ b/src/components/layout/TabNavigation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Image, Settings, BookOpen } from "lucide-react";
+import { Image, Settings, BookOpen, List } from "lucide-react";
 import type { TabState } from "@/types";
 
 interface TabNavigationProps {
@@ -27,6 +27,13 @@ export const TabNavigation: React.FC<TabNavigationProps> = ({
       shortLabel: "Best Practices",
       icon: BookOpen,
       description: "Manage best practices for your workflow",
+    },
+    {
+      id: "usage" as const,
+      label: "Usage & Costs",
+      shortLabel: "Usage",
+      icon: List,
+      description: "View usage statistics and costs",
     },
     {
       id: "settings" as const,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,7 +144,7 @@ export interface PersistedImageState {
 }
 
 export interface TabState {
-  activeTab: "image-to-prompt" | "settings" | "best-practices";
+  activeTab: "image-to-prompt" | "settings" | "best-practices" | "usage";
 }
 
 /**


### PR DESCRIPTION
## Title

Fix: Enable and display all navigation tabs

## What changed

- Added "Usage & Costs" tab to the navigation in `src/components/layout/TabNavigation.tsx`.
- Updated `TabState` type in `src/types/index.ts` to include `"usage"`.
- Imported and conditionally rendered `BestPracticesTab` and `UsageTab` components in `src/components/App.tsx` based on the active tab state.
- Introduced a new comprehensive integration test file `src/components/__tests__/App.tabs.test.tsx` to verify all tabs are present in navigation and render their respective content when clicked.

## Why

The "Best Practices" tab was defined but not rendered, appearing broken to users. The "Usage & Costs" tab was completely missing from both navigation and rendering. This PR fixes these issues by correctly wiring up both tabs in the application's UI and ensuring their content is displayed. A new, robust test suite has been added to prevent these types of regressions from occurring again.

## How to verify

1. Start the application locally (`npm start` or equivalent).
2. Observe the main navigation bar and confirm that "Image to Prompt", "Best Practices", "Usage & Costs", and "Settings" tabs are all visible.
3. Click on each of these four tabs and verify that the corresponding content area updates and displays the expected information (e.g., "Best Practices Tab Content", "Usage Tab Content").
4. Run the new tab integration tests: `npm test -- src/components/__tests__/App.tabs.test.tsx` and ensure all 7 tests pass.

## Risks / Limitations

- **Pre-existing Issues**: This PR does not address pre-existing lint errors or other failing tests unrelated to the tab functionality.
- **i18n**: The new user-facing string "Usage & Costs" in `TabNavigation.tsx` is hardcoded and not externalized for internationalization.
- **No UI Screenshot**: While UI changes are significant, no screenshot is provided in this PR.

## Size

~204/0 lines

## Definition of Done (DoD)

- [x] No secrets / .env added or modified
- [x] No changes under `.github/**` unless intentional and approved
- [ ] Lint clean (zero warnings): *Pre-existing lint errors are present, not introduced by this PR.*
- [x] Typecheck clean: `npm run typecheck`
- [x] Tests passing: `npm test -- --runInBand` *(New tab integration tests pass; pre-existing test failures exist but are unrelated to this change.)*
- [ ] Branch is up to date with `main`
- [x] Clear PR body (What/Why/How to verify + Risks + Size)
- [ ] Screenshot/GIF if UI changed: *UI changed, no screenshot provided.*
- [x] Acceptance criteria met; linked issue/epic; ADR linked or "N/A": *Acceptance criteria met.*
- [x] Backward compatibility preserved, or breaking change documented with migration path
- [ ] Feature guarded by a flag or has a safe rollout plan and kill switch
- [ ] Observability updated: logs/metrics/traces; alerts/dashboards updated or "N/A"
- [x] Performance budgets respected; no regressions verified locally (note perf risks if any)
- [x] Security/privacy reviewed: no PII in logs; deps changes pass audit
- [x] Accessibility verified (labels, keyboard nav, color contrast)
- [ ] API/schema changes documented; all consumers updated or "N/A"
- [ ] Data/storage migrations include scripts, tests, and rollback plan or "N/A"
- [ ] Documentation updated (user/dev); README/CHANGELOG updated if user-visible
- [x] Rollout and rollback plan captured in "How to verify" or "Risks": *Rollback: `git revert <sha>`*
- [x] Tests added/updated (unit/integration/e2e) for new behavior
- [ ] i18n: user-facing strings externalized and ready for translation or "N/A": *User-facing string "Usage & Costs" is hardcoded.*

---
<a href="https://cursor.com/background-agent?bcId=bc-d3e65a93-e2fa-441d-9895-c2976dc1bef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3e65a93-e2fa-441d-9895-c2976dc1bef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

